### PR TITLE
feat(saving)!: Overhaul localStorage saving system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptwordle",
-  "version": "1.0.617",
+  "version": "1.2.617",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/Character/CharacterSelect.tsx
+++ b/src/app/components/Character/CharacterSelect.tsx
@@ -1,8 +1,9 @@
 // src/app/components/CharacterSelect.tsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import Select from 'react-select';
 import { Character, CharacterRank } from '@/types';
 import CharacterPreview from './CharacterPreview';
+import { useState } from 'react';
 
 interface Props {
   characters: Character[];
@@ -17,6 +18,7 @@ interface OptionType {
 }
 
 const CharacterSelect: React.FC<Props> = ({ characters, onSelect, disabled }) => {
+  const [isMounted, setIsMounted] = useState(false);
   const options: OptionType[] = characters.map((character) => ({
     value: character.name,
     label: character.name,
@@ -40,8 +42,20 @@ const CharacterSelect: React.FC<Props> = ({ characters, onSelect, disabled }) =>
     </div>
   );
 
+
+  // makes rendering client-side only
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null;
+  }
+
+
   return (
     <Select
+      id='sinner-select'
       options={options}
       onChange={(selectedOption) => {
         if (selectedOption) {
@@ -114,9 +128,6 @@ const CharacterSelect: React.FC<Props> = ({ characters, onSelect, disabled }) =>
             </span>
           </div>
       }}
-    // components={{
-    //   SingleValue: ({ data }) => <div>The previous Sinner selected was {data.label}.</div>
-    // }}
     />
   );
 };

--- a/src/app/components/Character/CharacterSelect.tsx
+++ b/src/app/components/Character/CharacterSelect.tsx
@@ -49,7 +49,9 @@ const CharacterSelect: React.FC<Props> = ({ characters, onSelect, disabled }) =>
   }, []);
 
   if (!isMounted) {
-    return null;
+    return (
+      <div>Loading...</div>
+    )
   }
 
 

--- a/src/app/components/Game/GameController.css
+++ b/src/app/components/Game/GameController.css
@@ -1,5 +1,5 @@
 .game-display {
-  @apply flex flex-col sm:flex-row w-full justify-center items-center;
+  @apply flex flex-col sm:flex-row w-full justify-center items-center lg:min-h-[45rem];
 }
 
 .clock-container {

--- a/src/app/components/Game/GameStatus.tsx
+++ b/src/app/components/Game/GameStatus.tsx
@@ -19,7 +19,7 @@ const GameStatus: React.FC<GameStatusProps> = ({
 	guesses,
 	MAX_GUESSES,
 }) => {
-	const tries_grammar = `${guesses.length} ${guesses.length === 1 ? 'time' : 'times'}`;
+	const tries_grammar = `${guesses.length} ${guesses.length === 1 ? 'try' : 'tries'}`;
 	return (
 		<div className="flex flex-col items-center lg:w-1/2 mt-4 lg:mt-0">
 			<div className="text-center">
@@ -29,7 +29,7 @@ const GameStatus: React.FC<GameStatusProps> = ({
 							{gameWon ? 'Congratulations! You won!' : 'Game Over! You lost!'}
 						</h2>
 						<p className="text-lg">The character was {targetCharacter?.name}.</p>
-						<p className="text-lg">You tried {tries_grammar}.</p>
+						<p className="text-lg">You found the sinner in {tries_grammar}.</p>
 					</div>
 				) : (
 					<div>
@@ -43,7 +43,7 @@ const GameStatus: React.FC<GameStatusProps> = ({
 									src="/images/placeholder.png"
 									alt="Selected Character"
 									width={256}
-									height={576}
+									height={256}
 									className="object-cover h-full rounded-full mx-auto mb-2"
 									unoptimized={true}
 								/>

--- a/src/app/components/Game/GameStatus.tsx
+++ b/src/app/components/Game/GameStatus.tsx
@@ -34,7 +34,7 @@ const GameStatus: React.FC<GameStatusProps> = ({
 				) : (
 					<div>
 						<h2 className="text-2xl font-bold">Path to Nowordle</h2>
-						{hasGameStarted(guesses) ? (
+						{!hasGameStarted(guesses) ? (
 							<>
 								<p className="text-lg mb-2">
 									Try to find the daily Sinner.

--- a/src/app/components/Game/GameStatus.tsx
+++ b/src/app/components/Game/GameStatus.tsx
@@ -37,8 +37,12 @@ const GameStatus: React.FC<GameStatusProps> = ({
 						{guesses.length === 0 ? (
 							<>
 								<p className="text-lg mb-2">
-									Try to find the daily Sinner based on their characteristics.
+									Try to find the daily Sinner.
 								</p>
+								<p className="text-md mb-2">
+								Press the ? button on the top left corner to learn how to play.
+								</p>
+								
 								<Image
 									src="/images/placeholder.png"
 									alt="Selected Character"

--- a/src/app/components/Game/GameStatus.tsx
+++ b/src/app/components/Game/GameStatus.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Image from 'next/image';
 import EmojiGuesses from './EmojiGuesses';
 import { Attribute } from '@/types';
+import { hasGameStarted } from '@/lib/GameUtils';
 
 interface GameStatusProps {
 	gameOver: boolean;
@@ -34,7 +35,7 @@ const GameStatus: React.FC<GameStatusProps> = ({
 				) : (
 					<div>
 						<h2 className="text-2xl font-bold">Path to Nowordle</h2>
-						{guesses.length === 0 ? (
+						{hasGameStarted(guesses) ? (
 							<>
 								<p className="text-lg mb-2">
 									Try to find the daily Sinner.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Character, Attribute, AvailableGames } from "@/types";
 import { getSeededCharacter, calculateThresholds, getCharacterFromCode } from "@/lib/CharacterUtils";
-import { getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes, getCharacterListWithoutGuesses } from "@/lib/GameUtils";
+import { getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes, getCharacterListWithoutGuesses, hasGameStarted } from "@/lib/GameUtils";
 import { saveGame, loadGame, getLastPlayedGame } from "@/lib/SaveUtils";
 import GameController from "@/components/Game/GameController";
 import GuessTable from "@/components/Table/GuessTable";
@@ -52,7 +52,7 @@ export default function Home() {
     setSaveTarget(loaded_target);
 
     if (!is_game_over) {
-      if (loaded_game.data.guesses.length > 0) {
+      if (hasGameStarted(loaded_game.data.guesses)) {
         const last_character_guessed = getCharacterFromCode(loaded_game.data.guesses[loaded_game.data.guesses.length - 1]);
         setImageSrc(last_character_guessed.image_full)
       }
@@ -100,12 +100,12 @@ export default function Home() {
           guessDisabled={guessDisabled}
         />
 
-        {saveGuesses.length > 0 && (
+        {hasGameStarted(saveGuesses) && (
           <TableHeader attributeKeys={ATTRIBUTE_KEYS} reversed={reverseTable} onReverseChange={handleReverseChange} />
         )}
 
         <div className="flex flex-col mt-1 lg:mt-4" ref={lastRowRef}>
-          {saveGuesses.length > 0 && (
+          {hasGameStarted(saveGuesses) && (
             <GuessTable
               guesses={saveGuesses}
               target_guess={saveTarget}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Character, Attribute, GameState, Thresholds } from "@/types";
-import { getAllCharacters, getSeededCharacter, getUTCDate, calculateThresholds } from "@/lib/CharacterUtils";
+import { getAllCharacters, getSeededCharacter, calculateThresholds } from "@/lib/CharacterUtils";
 import { evaluateGuess } from "@/lib/GuessUtils";
-import { saveGameState, loadGameState } from "@/lib/GameUtils";
+import { saveGameState, loadGameState, getUTCDate } from "@/lib/GameUtils";
 import GameController from "@/components/Game/GameController";
 import GuessTable from "@/components/Table/GuessTable";
 import HeaderMenu from "@/app/components/HeaderMenu";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Character, Attribute, GameState, Thresholds, Game, AvailableGames } from "@/types";
 import { getAllCharacters, getSeededCharacter, calculateThresholds, getCharacterFromCode } from "@/lib/CharacterUtils";
 import { evaluateGuess } from "@/lib/GuessUtils";
-import { saveGameState, loadGameState, getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes } from "@/lib/GameUtils";
+import { saveGameState, loadGameState, getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes, getCharacterListWithoutGuesses } from "@/lib/GameUtils";
 import { saveGame, loadGame, createEmptySave, getLastPlayedGame, updateLastPlayed } from "@/lib/SaveUtils";
 import GameController from "@/components/Game/GameController";
 import GuessTable from "@/components/Table/GuessTable";
@@ -30,40 +30,54 @@ export default function Home() {
 
   const [currentGame, setCurrentGame] = useState<AvailableGames>("ptndle");
   const [saveGuesses, setSaveGuesses] = useState<Attribute[][]>([]);
-  const [saveTarget, setSaveTarget] = useState<Character>();
-  const [saveSeed, setSaveSeed] = useState<string>("");
+  const [saveTarget, setSaveTarget] = useState<Character>(getSeededCharacter());
+  const [saveSeed, setSaveSeed] = useState<string>(getUTCDate());
   const [saveWon, setSaveWon] = useState<boolean>(false);
   const [saveOver, setSaveOver] = useState<boolean>(false);
-
-
+  const [saveAllCharacters, setSaveAllCharacters] = useState<Character[]>([]);
 
   /** Toggles table order */
   const handleReverseChange = (newReverse: boolean) => setReverseTable(newReverse);
 
   /** Updates thresholds based on the target character */
   function updateThresholds() {
-    thresholds = calculateThresholds(targetCharacter!);
+    thresholds = calculateThresholds(getSeededCharacter(saveSeed)!);
   }
 
   function updateBasedOnSave(){
     const game_to_load = getLastPlayedGame();
     const loaded_game = loadGame(game_to_load);
-    // saveGame(loaded_game);
-    // updateLastPlayed(loaded_game);
+
     console.log("our current game data is", loaded_game);
 
     const loaded_seed = loaded_game.data.seed;
-    const is_game_won = isGameWon(loaded_game.data.guesses, getSeededCharacter(loaded_seed).code);
-    const is_game_over = isGameOver(loaded_game.data.guesses, getSeededCharacter(loaded_seed).code);
+    const loaded_target = getSeededCharacter(loaded_seed);
+    const is_game_won = isGameWon(loaded_game.data.guesses, loaded_target.code);
+    const is_game_over = isGameOver(loaded_game.data.guesses, loaded_target.code);
     const legacy_guesses = getLegacyGuessesFromCodes(loaded_game.data.guesses);
+
+    const filtered_characters = getCharacterListWithoutGuesses(loaded_game.data.guesses);
+    console.log("save sede", loaded_seed);
+
 
     setCurrentGame(loaded_game.name);
     setSaveGuesses(legacy_guesses);
     setSaveSeed(loaded_game.data.seed);
-    setSaveTarget(getSeededCharacter(loaded_seed));
+    setSaveTarget(loaded_target);
     setSaveWon(is_game_won);
     setSaveOver(is_game_over);
+    setSaveAllCharacters(filtered_characters);
+    setSaveTarget(loaded_target);
 
+
+    if(!is_game_over){
+      if(loaded_game.data.guesses.length > 0) {
+        const last_character_guessed = getCharacterFromCode(loaded_game.data.guesses[loaded_game.data.guesses.length - 1]);
+        setImageSrc(last_character_guessed.image_full)
+      }
+    } else {
+      setImageSrc(loaded_target.image_full);
+    }
 
     console.log("legacy guesses", legacy_guesses);
     console.log("is game won?", is_game_won);
@@ -73,119 +87,25 @@ export default function Home() {
 
   /** Initializes or Loads the Game */
   useEffect(() => {
-    const loadedGameState = loadGameState();
     updateBasedOnSave();
-
-    if (loadedGameState) {
-      loadedGameState.guesses.forEach((guess) => console.log(guess))
-      assert(loadedGameState.guesses.every((guess) => guess.length === 7)) // Assertion here for now for object representation check
-      const target_character = getSeededCharacter(loadedGameState.seed)
-      const is_game_won = loadedGameState.guesses.at(-1)?.[1].name === target_character.name 
-      // TODO: Define and implement CharacterAttributes to avoid short-circuiting
-      const is_game_over = is_game_won || loadedGameState.guesses.length === MAX_GUESSES
-      setGuesses(loadedGameState.guesses);
-      setGameOver(is_game_over);
-      setGameWon(is_game_won);
-      setSeed(loadedGameState.seed)
-    
-      setTargetCharacter(getSeededCharacter(loadedGameState.seed));
-
-      const guessedNames = loadedGameState.guesses.map((guess) => guess[1].value.toLowerCase());
-      const filteredCharacters = getAllCharacters().filter((c) => !guessedNames.includes(c.name.toLowerCase()));
-      setAllCharacters(filteredCharacters);
-
-      // Set last guessed character's image
-      if (!is_game_over) {
-        const lastGuess = loadedGameState.guesses.at(-1);
-        const lastGuessName = lastGuess?.[1]?.value;
-
-        const matchedCharacter = getAllCharacters().find((c) => c.name.toLowerCase() === lastGuessName?.toLowerCase());
-        setImageSrc(matchedCharacter?.image_full || "");
-      } else {
-        setImageSrc(target_character.image_full);
-      }
-    } else {
-      const newTarget = getSeededCharacter();
-      setSeed(getUTCDate());
-      setTargetCharacter(newTarget);
-      setAllCharacters(getAllCharacters());
-    }
   }, []);
 
-  /** Saves game state when game changes */
-  useEffect(() => {
-    if (targetCharacter) {
-      saveGameState({
-        guesses,
-        date: new Date().toISOString().split("T")[0], // YYYY-MM-DD format
-        seed: seed
-      });
-    }
-
-      const loaded_game = loadGame(currentGame);
-      console.log("guesses", guesses)
-      loaded_game.data.guesses = guesses.map((guess) => guess[2].value);
-      loaded_game.data.seed = seed;
-      saveGame(loaded_game);
-      updateBasedOnSave();
-  }, [guesses, gameOver, seed, targetCharacter]);
-
-  /** Scrolls to the last guess */
-  useEffect(() => {
-    if (lastRowRef.current && !reverseTable) {
-      setTimeout(() => {
-        lastRowRef.current?.scrollIntoView({ behavior: "smooth" });
-      }, 250);
-    }
-  }, [guesses]);
-
-  /** Handles a player's guess selection */
   const handleSelectCharacter = useCallback(
     (character: Character) => {
-      if (gameOver || guessDisabled) return;
+      if (saveOver || guessDisabled) return;
 
-      setImageSrc(character.image_full);
-      setAllCharacters((prev) => prev.filter((c) => c.name !== character.name));
-      setGuessDisabled(true);
+      const loaded_game = loadGame(currentGame);
+      loaded_game.data.guesses.push(character.code)
 
-      if (!targetCharacter) {
-        console.error("Target character is null.");
-        return;
-      }
-
-      const evaluatedGuesses = evaluateGuess({ character, target: targetCharacter, thresholds });
-      setGuesses((prevGuesses) => [...prevGuesses, evaluatedGuesses]);
-
-      if (evaluatedGuesses.every((attr) => attr.state === "correct")) {
-        setGameWon(true);
-        setGameOver(true);
-        setImageSrc(targetCharacter.image_full);
-      } else if (guesses.length + 1 === MAX_GUESSES) {
-        setGameOver(true);
-        setImageSrc(targetCharacter.image_full);
-      }
+      saveGame(loaded_game);
+      updateBasedOnSave();
 
       setTimeout(() => setGuessDisabled(false), 500);
     },
     [gameOver, guessDisabled, guesses, targetCharacter, allCharacters, thresholds]
   );
 
-  /** Resets the game with a new target character */
-  const handleNewTarget = () => {
-    localStorage.removeItem("gameState");
-    const new_seed = (Math.random() * 1000).toString();
-    setSeed(new_seed)
-    const new_target = getSeededCharacter(new_seed);
-    calculateThresholds(new_target);
-    setTargetCharacter(new_target);
-    setAllCharacters(getAllCharacters());
-    setGuesses([]);
-    setGameOver(false);
-    setGameWon(false);
-    setImageSrc("");
-  };
-
-  if (!targetCharacter) return <div>Loading...</div>;
+  if (!saveTarget) return <div>Loading...</div>;
 
   return (
     <>
@@ -197,30 +117,23 @@ export default function Home() {
           imageSrc={imageSrc ?? ""}
           gameOver={saveOver}
           gameWon={saveWon}
-          targetCharacter={targetCharacter}
+          targetCharacter={saveTarget}
           guesses={saveGuesses}
           MAX_GUESSES={MAX_GUESSES}
-          allCharacters={allCharacters}
+          allCharacters={saveAllCharacters}
           handleSelectCharacter={handleSelectCharacter}
           guessDisabled={guessDisabled}
         />
 
-        <button
-          onClick={handleNewTarget}
-          className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md"
-        >
-          New Target
-        </button>
-
-        {guesses.length > 0 && (
+        {saveGuesses.length > 0 && (
           <TableHeader attributeKeys={ATTRIBUTE_KEYS} reversed={reverseTable} onReverseChange={handleReverseChange} />
         )}
 
         <div className="flex flex-col mt-1 lg:mt-4" ref={lastRowRef}>
-          {guesses.length > 0 && (
+          {saveGuesses.length > 0 && (
             <GuessTable
               guesses={saveGuesses}
-              target_guess={targetCharacter}
+              target_guess={saveTarget}
               thresholds={thresholds}
               reverse={reverseTable}
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,23 @@
 "use client";
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { Character, Attribute, GameState, Thresholds, Game, AvailableGames } from "@/types";
-import { getAllCharacters, getSeededCharacter, calculateThresholds, getCharacterFromCode } from "@/lib/CharacterUtils";
-import { evaluateGuess } from "@/lib/GuessUtils";
-import { saveGameState, loadGameState, getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes, getCharacterListWithoutGuesses } from "@/lib/GameUtils";
-import { saveGame, loadGame, createEmptySave, getLastPlayedGame, updateLastPlayed } from "@/lib/SaveUtils";
+import { Character, Attribute, AvailableGames } from "@/types";
+import { getSeededCharacter, calculateThresholds, getCharacterFromCode } from "@/lib/CharacterUtils";
+import { getUTCDate, isGameWon, isGameOver, getLegacyGuessesFromCodes, getCharacterListWithoutGuesses } from "@/lib/GameUtils";
+import { saveGame, loadGame, getLastPlayedGame } from "@/lib/SaveUtils";
 import GameController from "@/components/Game/GameController";
 import GuessTable from "@/components/Table/GuessTable";
 import HeaderMenu from "@/app/components/HeaderMenu";
 import TableHeader from "@/components/Table/TableHeader";
-import assert from "assert";
 
 const MAX_GUESSES = 6;
 const ATTRIBUTE_KEYS = ["code", "alignment", "tendency", "height", "birthplace"];
-const APP_VERSION = "beta v1.1.617";
+const APP_VERSION = "beta v1.2.617";
 
 export default function Home() {
-  const [targetCharacter, setTargetCharacter] = useState<Character | null>(null);
-  const [seed, setSeed] = useState<string>("") // targetCharacter is kinda redundent with seed as well
-  const [allCharacters, setAllCharacters] = useState<Character[]>([]);
-  const [guesses, setGuesses] = useState<Attribute[][]>([]);
   const [guessDisabled, setGuessDisabled] = useState(false);
-  const [gameOver, setGameOver] = useState(false);
-  const [gameWon, setGameWon] = useState(false);
   const [imageSrc, setImageSrc] = useState<string>("");
   const [reverseTable, setReverseTable] = useState(false);
   const lastRowRef = useRef<HTMLDivElement>(null);
-  let thresholds: Thresholds = { code: { high: 0, very_high: 0 }, height: { high: 0, very_high: 0 } };
 
   const [currentGame, setCurrentGame] = useState<AvailableGames>("ptndle");
   const [saveGuesses, setSaveGuesses] = useState<Attribute[][]>([]);
@@ -39,16 +30,9 @@ export default function Home() {
   /** Toggles table order */
   const handleReverseChange = (newReverse: boolean) => setReverseTable(newReverse);
 
-  /** Updates thresholds based on the target character */
-  function updateThresholds() {
-    thresholds = calculateThresholds(getSeededCharacter(saveSeed)!);
-  }
-
-  function updateBasedOnSave(){
+  function updateBasedOnSave() {
     const game_to_load = getLastPlayedGame();
     const loaded_game = loadGame(game_to_load);
-
-    console.log("our current game data is", loaded_game);
 
     const loaded_seed = loaded_game.data.seed;
     const loaded_target = getSeededCharacter(loaded_seed);
@@ -57,8 +41,6 @@ export default function Home() {
     const legacy_guesses = getLegacyGuessesFromCodes(loaded_game.data.guesses);
 
     const filtered_characters = getCharacterListWithoutGuesses(loaded_game.data.guesses);
-    console.log("save sede", loaded_seed);
-
 
     setCurrentGame(loaded_game.name);
     setSaveGuesses(legacy_guesses);
@@ -69,23 +51,17 @@ export default function Home() {
     setSaveAllCharacters(filtered_characters);
     setSaveTarget(loaded_target);
 
-
-    if(!is_game_over){
-      if(loaded_game.data.guesses.length > 0) {
+    if (!is_game_over) {
+      if (loaded_game.data.guesses.length > 0) {
         const last_character_guessed = getCharacterFromCode(loaded_game.data.guesses[loaded_game.data.guesses.length - 1]);
         setImageSrc(last_character_guessed.image_full)
       }
     } else {
       setImageSrc(loaded_target.image_full);
     }
-
-    console.log("legacy guesses", legacy_guesses);
-    console.log("is game won?", is_game_won);
-    console.log("is game over?", is_game_over);
-
   }
 
-  /** Initializes or Loads the Game */
+  // initial game load
   useEffect(() => {
     updateBasedOnSave();
   }, []);
@@ -102,14 +78,13 @@ export default function Home() {
 
       setTimeout(() => setGuessDisabled(false), 500);
     },
-    [gameOver, guessDisabled, guesses, targetCharacter, allCharacters, thresholds]
+    [guessDisabled]
   );
 
   if (!saveTarget) return <div>Loading...</div>;
 
   return (
     <>
-      {updateThresholds()}
       <div className="flex flex-col items-center min-h-screen relative">
         <HeaderMenu appVersion={APP_VERSION} />
 
@@ -134,7 +109,7 @@ export default function Home() {
             <GuessTable
               guesses={saveGuesses}
               target_guess={saveTarget}
-              thresholds={thresholds}
+              thresholds={calculateThresholds(getSeededCharacter(saveSeed)!)}
               reverse={reverseTable}
             />
           )}

--- a/src/lib/CharacterUtils.ts
+++ b/src/lib/CharacterUtils.ts
@@ -17,6 +17,19 @@ export function getSeededCharacter(date: string = getUTCDate()): Character {
   return seeded_character;
 }
 
+export function getCharacterFromCode(code: string): Character {
+  const foundCharacter = DEFAULT_CHARACTERS.find(
+    (character) => character.code === code
+  );
+
+  if (!foundCharacter) {
+    throw new Error(`Character with code ${code} not found.`);
+  }
+  
+  return foundCharacter;
+
+}
+
 // 2025-02-23
 // https://stackoverflow.com/a/52171480
 // https://github.com/bryc/code/blob/fdd2d21471febe58c7879707c0f43a65e1dd8248/jshash/experimental/cyrb53.js

--- a/src/lib/CharacterUtils.ts
+++ b/src/lib/CharacterUtils.ts
@@ -5,6 +5,7 @@ import {
   Thresholds,
 } from "@/types";
 import characterData from "@/character_data/characters.json";
+import { getUTCDate } from "@/lib/GameUtils";
 
 const DEFAULT_CHARACTERS: Character[] = characterData as Character[];
 
@@ -14,10 +15,6 @@ export function getSeededCharacter(date: string = getUTCDate()): Character {
   const seeded_character = DEFAULT_CHARACTERS[index];
   console.log(seeded_character);
   return seeded_character;
-}
-
-export function getUTCDate(date: Date = new Date()): string {
-  return date.toISOString().split("T")[0];
 }
 
 // 2025-02-23

--- a/src/lib/GameUtils.ts
+++ b/src/lib/GameUtils.ts
@@ -37,6 +37,10 @@ export function getCharacterListWithoutGuesses(guesses: string[]): Character[] {
 	return characters.filter(character => !guesses.includes(character.code));
 }
 
+export function hasGameStarted(guesses: string[] | Attribute[][]): boolean {
+  return guesses.length > 0;
+}
+
 
 export function getLegacyGuessesFromCodes(codes: string[], seed: string = getUTCDate()): Attribute[][] {
   const characters = getCharactersFromCodes(codes);

--- a/src/lib/GameUtils.ts
+++ b/src/lib/GameUtils.ts
@@ -25,8 +25,8 @@ export const loadGameState = (): GameState | null => {
   if (!savedState) return null;
 
   const gameState: GameState = JSON.parse(savedState);
-  const savedDate = new Date(gameState.date).toISOString().split("T")[0];
-  const currentDate = new Date().toISOString().split("T")[0];
+  const currentDate = getUTCDate();
+  const savedDate = getUTCDate(new Date(gameState.date));
 
   if (savedDate === currentDate) {
     return gameState;
@@ -34,5 +34,9 @@ export const loadGameState = (): GameState | null => {
     localStorage.removeItem("gameState");
     return null;
   }
-};
+}
+
+export function getUTCDate(date: Date = new Date()): string {
+  return date.toISOString().split("T")[0];
+}
 

--- a/src/lib/GameUtils.ts
+++ b/src/lib/GameUtils.ts
@@ -1,5 +1,5 @@
 // src/lib/GameUtils.ts
-import { Character, Attribute, Thresholds, GameState, Guess } from "@/types";
+import { Character, Attribute, Guess } from "@/types";
 import {
 	getAllCharacters,
 	getSeededCharacter,
@@ -13,33 +13,6 @@ export const MAX_GUESSES = 6;
 
 // Attribute keys used in the table
 export const ATTRIBUTE_KEYS = ["code", "alignment", "tendency", "height", "birthplace"];
-
-/**
- * Saves the game state to local storage.
- */
-export const saveGameState = (gameState: GameState) => {
-  localStorage.setItem("gameState", JSON.stringify(gameState));
-};
-
-/**
- * Loads the game state from local storage if it's from today. 
- * Creates a new one otherwise.
- */
-export const loadGameState = (): GameState | null => {
-  const savedState = localStorage.getItem("gameState");
-  if (!savedState) return null;
-
-  const gameState: GameState = JSON.parse(savedState);
-  const currentDate = getUTCDate();
-  const savedDate = getUTCDate(new Date(gameState.date));
-
-  if (savedDate === currentDate) {
-    return gameState;
-  } else {
-    localStorage.removeItem("gameState");
-    return null;
-  }
-}
 
 export function getUTCDate(date: Date = new Date()): string {
   return date.toISOString().split("T")[0];

--- a/src/lib/GameUtils.ts
+++ b/src/lib/GameUtils.ts
@@ -1,6 +1,11 @@
 // src/lib/GameUtils.ts
-import { Character, Attribute, Thresholds, GameState } from "@/types";
-import { getAllCharacters, getSeededCharacter, calculateThresholds } from "@/lib/CharacterUtils";
+import { Character, Attribute, Thresholds, GameState, Guess } from "@/types";
+import {
+	getAllCharacters,
+	getSeededCharacter,
+	calculateThresholds,
+	getCharacterFromCode,
+} from "@/lib/CharacterUtils";
 import { evaluateGuess } from "@/lib/GuessUtils";
 
 // Maximum guesses allowed
@@ -39,4 +44,40 @@ export const loadGameState = (): GameState | null => {
 export function getUTCDate(date: Date = new Date()): string {
   return date.toISOString().split("T")[0];
 }
+
+export function isGameWon(guesses: string[], target: string): boolean {
+	return guesses.includes(target);
+}
+
+export function isGameOver(guesses: string[], target: string): boolean {
+	if (isGameWon(guesses, target)) return true;
+	return guesses.length >= MAX_GUESSES;
+}
+
+export function getCharactersFromCodes(guesses: string[]): Character[] {
+	return guesses.map(guess => getCharacterFromCode(guess));
+}
+
+export function getLegacyGuessesFromCodes(codes: string[], seed: string = getUTCDate()): Attribute[][] {
+  const characters = getCharactersFromCodes(codes);
+  const target = getSeededCharacter(seed);
+  const thresholds = calculateThresholds(target);
+
+  const legacy_guesses = [];
+  
+  for (const character of characters) {
+    const guess: Guess = {
+      character: character,
+      target: target,
+      thresholds: thresholds,
+    };
+
+    legacy_guesses.push(evaluateGuess(guess));
+  }
+
+  return legacy_guesses;
+
+}
+	
+	
 

--- a/src/lib/GameUtils.ts
+++ b/src/lib/GameUtils.ts
@@ -58,6 +58,13 @@ export function getCharactersFromCodes(guesses: string[]): Character[] {
 	return guesses.map(guess => getCharacterFromCode(guess));
 }
 
+export function getCharacterListWithoutGuesses(guesses: string[]): Character[] {
+	const characters = getAllCharacters();
+  
+	return characters.filter(character => !guesses.includes(character.code));
+}
+
+
 export function getLegacyGuessesFromCodes(codes: string[], seed: string = getUTCDate()): Attribute[][] {
   const characters = getCharactersFromCodes(codes);
   const target = getSeededCharacter(seed);

--- a/src/lib/GuessUtils.ts
+++ b/src/lib/GuessUtils.ts
@@ -26,7 +26,7 @@ export function EvaluateNumericalGuess(
     const distance_from_target = Math.abs(guessed_value - target_value);
 
     if (distance_from_target == 0)                             return {comparison: undefined, description: "correct"};
-    if (distance_from_target < threshold)                      return {comparison: "≅", description: "close"};
+    if (distance_from_target <= threshold)                      return {comparison: "≅", description: "close"};
     if (is_positive && distance_from_target > far_threshold)   return {comparison: "↑↑", description: "much higher"};
     if (is_positive && distance_from_target <= far_threshold)  return {comparison: "↑", description: "higher"};
     if (!is_positive && distance_from_target > far_threshold)  return {comparison: "↓↓", description: "much lower"};

--- a/src/lib/SaveUtils.ts
+++ b/src/lib/SaveUtils.ts
@@ -6,6 +6,40 @@ const LOCALSTORAGE_KEY = "user_games";
 const DEFAULT_GAME = "ptndle";
 
 /**
+ * SAVING OVERVIEW
+ * 
+ * CONSIDERATIONS
+ * 
+ * 0.	Any outgoing return should be a structuredClone* to avoid references from changing during our save proccess. Yes, this WILL happen! Almost everything is running
+ * 		asynchronously. At the very least, a JSON parse and stringify should be done. 
+ * 		*most browsers updated >= 2022 should support this
+ * 
+ * 1. 	Our strategy here is to ALWAYS save to localStorage whenever possible. So, saveGame should be one of the most common functions here.
+ * 		We are doing this so we can scrap all of our other systems and just loadGame() whenever we want some information.
+ * 
+ * 		E.g., I am creating a new game type. I update AvailableGames to include it, and then change our front-end to display it.
+ * 		      We can now simply just loadGame(new_game), and our entire codebase should adapt to it.
+ * 		As of version 1.1, we have to create new variables for every single game.
+ * 
+ * 2.	 Our save directly overwrites the localStorage. There is absolutely no checking whatsoever. Always loadGame() and modify it directly before trying to save!
+ * 
+ * 3.   We trust any external usage of this file to call saveGame() by themselves, while all internal functions try to saveGame() if anything changes.
+ * 
+ * 4.   UserGames is an OBJECT, not an ARRAY. This means that we can have game_name as the key for any games. However, trying to use array functions might get you an
+ * 		empty value []. Be careful.
+ * 
+ * ERROR HANDLING
+ * 
+ * - If a game cannot be loaded, a new empty save is created to avoid further errors.
+ * - If there is no saved data, an empty object is returned.
+ * - If a game is not found, a new empty save is created.
+ * - If X, create new save. We want to ALWAYS have a save in hand.
+ * 
+ * 
+ * 
+ */
+
+/**
  * Loads a game from local storage.
  * @param game_name - The name of the game to load.
  * @returns The loaded game data, or a new empty game if it doesn't exist.

--- a/src/lib/SaveUtils.ts
+++ b/src/lib/SaveUtils.ts
@@ -1,0 +1,165 @@
+// src/lib/SaveUtils.ts
+import { AvailableGames, Game, UserGames } from "@/types";
+import { getUTCDate } from "@/lib/GameUtils";
+
+const LOCALSTORAGE_KEY = "user_games";
+const DEFAULT_GAME = "ptndle";
+
+/**
+ * Loads a game from local storage.
+ * @param game_name - The name of the game to load.
+ * @returns The loaded game data, or a new empty game if it doesn't exist.
+ */
+function loadGame(game_name: AvailableGames): Game {
+	try{
+		const game_data: Game = findGame(game_name);
+		
+		return structuredClone(game_data)
+
+	} catch (error) { 
+		// TODO: create proper error instances
+		console.error(error);
+		console.warn(`An error has occured. Forcefully creating a new empty ${game_name} save instance to avoid further errors.`);
+		return createEmptySave(game_name)
+	}
+}
+
+/**
+ * Updates the last played date of a game and saves it.
+ * @param game - The game to update.
+ */
+function updateLastPlayed(game: Game): void {
+	game.dates.last_played = getUTCDate(); 
+	saveGame(game);
+}
+
+/**
+ * Creates an empty game_name game, and directly saves it to localStorage.
+ * @param game_name - The name of the game to create. Defaults to DEFAULT_GAME.
+ * @returns A new empty game object.
+ */
+function createEmptySave(game_name: AvailableGames = DEFAULT_GAME): Game {
+	const today = getUTCDate();
+
+	const empty_game: Game = {
+		name: game_name,
+		dates: {
+			first_played: today,
+			last_played: today,
+		},
+		scoring: {
+			streak: 0,
+			high_score: 0,
+		},
+		data: {
+			guesses: [],
+			target: "",
+			seed: today,
+		},
+	};
+
+	saveGame(empty_game);
+	
+	return structuredClone(empty_game);
+}
+
+/**
+ * Saves a game to local storage.
+ * @param game - The game to save.
+ */
+function saveGame(game: Game): void { 
+	const user_games_string = localStorage.getItem(LOCALSTORAGE_KEY); 
+	const user_games = user_games_string ? JSON.parse(user_games_string) : {};
+
+	user_games[game.name] = game;
+
+	localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(user_games));
+}
+
+/**
+ * Finds a game in local storage based on their name.
+ * @param game_name - The name of the game to find.
+ * @returns The game data, or a new empty game if it doesn't exist.
+ */
+
+function findGame(game_name: AvailableGames): Game {
+	const games = getAllGames();
+
+	// we have nothing saved at all
+	if(!doesUserHaveGames(games)) return createEmptySave(game_name);
+
+	const game_data: Game = games[game_name];
+	
+	// we have something saved, but not the game we are trying to find
+	if(!game_data) return createEmptySave(game_name);
+
+	return structuredClone(game_data);
+}
+
+/**
+ * Gets all saved games from local storage. Note that since we are returning an empty object in some cases, you may have to 
+ * do manual checking for your use case.
+ * 
+ * This function exists solely so we can more easily handle updates in the future,
+ * 
+ * @returns An object containing all saved games, or an empty object if none exist.
+ */
+
+function getAllGames(): UserGames {
+	const saved_data = localStorage.getItem(LOCALSTORAGE_KEY);
+
+	if(!saved_data) return {} as UserGames;
+
+	return JSON.parse(saved_data);
+}
+
+/**
+ * Checks if the user has any saved games.
+ * @param games - The object containing all saved games.
+ * @returns True if the user has saved games, false otherwise.
+ */
+function doesUserHaveGames(games: UserGames): boolean {
+	return Object.keys(games).length > 0;
+}
+
+/**
+ * Gets the name of the last played game, based on their date.
+ * 
+ * @returns The name of the last played game. If there are none, defaults to 'ptndle'.
+ */
+function getLastPlayedGame(): AvailableGames {
+	let game_name: AvailableGames = "ptndle";
+
+	const games = getAllGames();
+
+	if (!doesUserHaveGames(games)) {
+		console.log("since games is empty, returning default value")
+		return game_name;
+	}
+
+	// ALL dates are strings
+	let last_played_date = "0000-00-00";
+	
+	for (const key in games) {
+		const game = games[key as AvailableGames];
+		
+		if(game.dates.last_played > last_played_date) {
+			last_played_date = game.dates.last_played;
+			game_name = game.name;
+		}
+	}	
+
+	console.log("found games. the most recent game is", game_name);
+
+	return game_name;
+
+}
+
+export {
+	saveGame,
+	loadGame,
+	createEmptySave,
+	updateLastPlayed,
+	getLastPlayedGame,
+	getAllGames
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,32 @@ export type GameState = {
   seed: string; // Seed for cheating prevention
 };
 
+export type AvailableGames = "ptndle" | "ptndle_endless";
+
+export type Game = {
+  name: AvailableGames;
+  dates: {
+    first_played: string;
+    last_played: string;
+  };
+  scoring: {
+    streak: number;
+    high_score: number;
+  }
+  data: {
+    guesses: string[] 
+    seed: string;
+    target?: string; // fallback, but we should be able to always get the same target using the same seed
+  }
+  user_configs?: string;
+  debug_info?: string;
+}
+
+// as we plan to have the AvailableGames as key, we need an object and not an array
+export type UserGames = {
+  [key in AvailableGames]: Game;
+}
+
 export type CharacterAttributes = [
   { name: "image"; value: string, state: string, rank: string},
   { name: "name"; value: string, state: string, rank: string},

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,9 @@ export type Game = {
     seed: string;
     target?: string; // fallback, but we should be able to always get the same target using the same seed
   }
+  history?: {
+    [date: string]: string[]
+  }
   user_configs?: string;
   debug_info?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,12 +42,6 @@ export type Guess = {
   thresholds: Thresholds;
 }
 
-export type GameState = {
-  guesses: Attribute[][]; // Why is this storing attributes instead of characters??
-  date: string; // Date string (YYYY-MM-DD)
-  seed: string; // Seed for cheating prevention
-};
-
 export type AvailableGames = "ptndle" | "ptndle_endless";
 
 export type Game = {


### PR DESCRIPTION
Our previous saving system was a complete mess. It was a total ad-hoc addition, and caused many bugs (see #4). 

By completely extracting all existing code, reworking it, and creating proper Types for them, we can ensure that it, at the very least, works consistently.

With our SaveUtils.ts file, we can now easily track user data (via localStorage), and implement new game types - it is as simple as just adding a new supported game name, and then switching to it via whichever means necessary. Most of the time this might mean clicking a button.

For this pull request, we have not directly changed anything related to seeding or daily characters. Yet, the saving system now should support different ways to do that, if needed. E.g., tracking endless-mode seeds in the future.
